### PR TITLE
Suggested changes to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,24 +8,24 @@
 
 ## Why?
 
-**Encrypting User/Personal data** stored by your Web App is ***essential***
+**Encrypting User/Personal data** stored by your Web App is **_essential_**
 for security/privacy.
 
 > If your app offers any **personalised content** or interaction
-that depends on "**login**", it is **_storing_ personal data**
-(_by definition_).
-You might be tempted to think that
-data is "safe" in a database, but it's _not_.
-There is an entire ("dark") army/industry of people
-([_cybercriminals_](https://en.wikipedia.org/wiki/Cybercrime))
-who target websites/apps attempting to "steal" data by compromising databases.
-All the time you spend _building_ your app,
-they spend trying to "_break_" apps like yours.  
-Don't let the people using your app
-be the victims of identity theft,
-protect their personal data!
-(_it's both the "**right**" **thing to do** and the
- [**law**](https://github.com/dwyl/learn-security/#gdpr) ..._)
+> that depends on "**login**", it is **_storing_ personal data**
+> (_by definition_).
+> You might be tempted to think that
+> data is "safe" in a database, but it's _not_.
+> There is an entire ("dark") army/industry of people
+> ([_cybercriminals_](https://en.wikipedia.org/wiki/Cybercrime))
+> who target websites/apps attempting to "steal" data by compromising databases.
+> All the time you spend _building_ your app,
+> they spend trying to "_break_" apps like yours.  
+> Don't let the people using your app
+> be the victims of identity theft,
+> protect their personal data!
+> (_it's both the "**right**" **thing to do** and the
+> [**law**](https://github.com/dwyl/learn-security/#gdpr) ..._)
 
 ## What?
 
@@ -33,8 +33,8 @@ This example/tutorial is intended as a _comprehensive_ answer
 to the question:
 
 > ["_**How to Encrypt/Decrypt Sensitive Data** in `Elixir` Apps
-**Before** Inserting (Saving) it into the
-Database?_"](https://github.com/dwyl/learn-elixir/issues/80)
+> **Before** Inserting (Saving) it into the
+> Database?_"](https://github.com/dwyl/learn-elixir/issues/80)
 
 ### Technical Overview
 
@@ -47,49 +47,50 @@ We are _following_ a **_battle-tested_ industry-standard** approach
 and applying it to our Elixir/Phoenix App. <br />
 We are using:
 
-+ **Advanced Encryption Standard** (**AES**) to encrypt sensitive data.
-  + **Galois/Counter Mode**
-for _symmetric_ key cryptographic block ciphers:
-https://en.wikipedia.org/wiki/Galois/Counter_Mode
-recommended many security and cryptography practitioners including
- [Matthew Green](https://blog.cryptographyengineering.com/),
- [Niels Ferguson](https://en.wikipedia.org/wiki/Niels_Ferguson)
- and [Bruce Schneier](https://www.schneier.com/blog/about/)
-  + "Under the hood" we are using Erlang's
-[crypto](http://erlang.org/doc/man/crypto.html) library
-_specifically_ AES with **256 bit keys** <br />
-(_the same as AWS or Google's KMS service_)
-see: http://erlang.org/doc/man/crypto.html#block_encrypt-4
-+ Password "hashing" using the **Argon2**
-key derivation function (KDF): https://en.wikipedia.org/wiki/Argon2 <br />
-_specifically_ the Elixir implementation of `argon2`
-written by David Whitlock: https://github.com/riverrun/argon2_elixir
-which in turn uses the **C** "_reference implementation_"
-as a "Git Submodule".
+* **Advanced Encryption Standard** (**AES**) to encrypt sensitive data.
+  * **Galois/Counter Mode**
+    for _symmetric_ key cryptographic block ciphers:
+    https://en.wikipedia.org/wiki/Galois/Counter_Mode
+    recommended by many security and cryptography practitioners including
+    [Matthew Green](https://blog.cryptographyengineering.com/),
+    [Niels Ferguson](https://en.wikipedia.org/wiki/Niels_Ferguson)
+    and [Bruce Schneier](https://www.schneier.com/blog/about/)
+  * "Under the hood" we are using Erlang's
+    [crypto](http://erlang.org/doc/man/crypto.html) library
+    _specifically_ AES with **256 bit keys** <br />
+    (_the same as AWS or Google's KMS service_)
+    see: http://erlang.org/doc/man/crypto.html#block_encrypt-4
+* Password "hashing" using the **Argon2**
+  key derivation function (KDF): https://en.wikipedia.org/wiki/Argon2 <br />
+  _specifically_ the Elixir implementation of `argon2`
+  written by David Whitlock: https://github.com/riverrun/argon2_elixir
+  which in turn uses the **C** "_reference implementation_"
+  as a "Git Submodule".
 
 > `¯\_(ツ)_/¯...?` Don't be "put off" if any of these terms/algorithms
-are _unfamiliar_ to you; <br />
-this example is "***step-by-step***"
-and we are _happy_ to answer/clarify
-_any_ (_relevant and specific_) questions you have!
+> are _unfamiliar_ to you; <br />
+> this example is "**_step-by-step_**"
+> and we are _happy_ to answer/clarify
+> _any_ (_relevant and specific_) questions you have!
 
 #### OWASP Cryptographic Rules?
 
 This example/tutorial follows
 the Open Web Application Security Project (**OWASP**)
 Cryptographic and Password rules:
-+ [x] Use "***strong approved Authenticated Encryption***"
-based on an ***AES algorithm***.
-  + [x] Use GCM mode of operation for symmetric key cryptographic block ciphers.
-  + [x] Keys used for encryption must be rotated at least annually.
-+ [x] Only use approved public algorithm **SHA-256** or better for hashing.
-+ [x] **Argon2** is the winner of the password hashing competition
-and should be your ***first choice*** for **_new_ applications**.
+
+* [x] Use "**_strong approved Authenticated Encryption_**"
+      based on an **_AES algorithm_**.
+  * [x] Use GCM mode of operation for symmetric key cryptographic block ciphers.
+  * [x] Keys used for encryption must be rotated at least annually.
+* [x] Only use approved public algorithm **SHA-256** or better for hashing.
+* [x] **Argon2** is the winner of the password hashing competition
+      and should be your **_first choice_** for **_new_ applications**.
 
 See:
-+ [https://www.owasp.org/index.php/Cryptographic_Storage_Cheat_Sheet](https://www.owasp.org/index.php/Cryptographic_Storage_Cheat_Sheet#Rule_-_Use_strong_approved_Authenticated_Encryption)
-+ https://www.owasp.org/index.php/Password_Storage_Cheat_Sheet
 
+* [https://www.owasp.org/index.php/Cryptographic_Storage_Cheat_Sheet](https://www.owasp.org/index.php/Cryptographic_Storage_Cheat_Sheet#Rule_-_Use_strong_approved_Authenticated_Encryption)
+* https://www.owasp.org/index.php/Password_Storage_Cheat_Sheet
 
 ## Who?
 
@@ -102,16 +103,16 @@ and _decrypting_ when it is queried.
 
 ### Prerequisites?
 
-+ Basic **`Elixir`** syntax knowledge: https://github.com/dwyl/learn-elixir
-+ Familiarity with the **`Phoenix`** framework.
-+ Basic understanding of **`Ecto`**
-(_the module used to interface with databases in elixir/phoenix_)
+* Basic **`Elixir`** syntax knowledge: https://github.com/dwyl/learn-elixir
+* Familiarity with the **`Phoenix`** framework: https://github.com/dwyl/learn-phoenix-framework
+* Basic understanding of **`Ecto`**
+  (_the module used to interface with databases in elixir/phoenix_)
 
 > If you are totally `new` to (_or "rusty" on_)
-Elixir, Phoenix or Ecto,
-we recommend going through our **Phoenix Chat Example**
-(_Beginner's Tutorial_) _first_:
-https://github.com/dwyl/phoenix-chat-example
+> Elixir, Phoenix or Ecto,
+> we recommend going through our **Phoenix Chat Example**
+> (_Beginner's Tutorial_) _first_:
+> https://github.com/dwyl/phoenix-chat-example
 
 ### Crypto Knowledge?
 
@@ -119,8 +120,8 @@ You will _not_ need any "advanced" mathematical knowledge;
 we are _not_ "inventing" our own encryption or
 going into the "internals" of any cyphers/algorithms/schemes. <br />
 
-You do _not_ need to _understand_
-how the encryption/hashing algorithms _work_, <br />
+**You do _not_ need to _understand_
+how the encryption/hashing algorithms _work_,** <br />
 but it is _useful_ to **know the _difference_** between
 [encryption](https://en.wikipedia.org/wiki/Encryption)
 vs.
@@ -138,15 +139,13 @@ should be "enough" for _most_ people who just want to focus
 on building their app and don't want to
 ["_go down the rabbit hole_"](https://youtu.be/6IDT3MpSCKI?t=1m2s). <br />
 
-_However_ ...  We have included 30+ links in the
+_However_ ... We have included 30+ links in the
 ["Useful Links"](https://github.com/dwyl/phoenix-ecto-encryption-example#useful-links-faq--background-reading)
 section at the _end_ of this readme.
 The list includes several common questions (_and **answers**_)
 so if you are _curious_, you can [learn](https://youtu.be/hOZnP4dZYK0).
 
-> _**Note**: in the @dwyl Library we have_
-https://www.schneier.com/books/applied_cryptography
-_So, if you're **really curious** let us know!_
+> _**Note**: in the @dwyl Library we have_ > https://www.schneier.com/books/applied_cryptography > _So, if you're **really curious** let us know!_
 
 ### Time Requirement?
 
@@ -157,19 +156,19 @@ will take around **1 hour** <br />
 (_including reading a few of the links_).
 
 > _**Invest** the time **up-front** to **avoid** on the **embarrassment**
-and [**fines**](https://www.itgovernance.co.uk/dpa-and-gdpr-penalties)
-of a data breach_.
-
+> and [**fines**](https://www.itgovernance.co.uk/dpa-and-gdpr-penalties)
+> of a data breach_.
 
 ## How?
 
 These are "step-by-step" instructions,
 don't skip any step(s).
 
-### 1. Creat the `encryption` App
+### 1. Create the `encryption` App
 
 In your Terminal,
-***create*** a `new` Phoenix application called "encryption":
+**_create_** a `new` Phoenix application called "encryption":
+
 ```sh
 mix phx.new encryption
 ```
@@ -203,48 +202,51 @@ You can also run your app inside IEx (Interactive Elixir) as:
 
 Follow the _first_ instruction
 **change** into the `encryption` directory: <br />
+
 ```sh
 cd encryption
 ```
 
-Next ***create*** the database for the App using the command:
+Next **_create_** the database for the App using the command:
+
 ```sh
 mix ecto.create
 ```
 
 You should see the following output:
+
 ```sh
 Compiling 13 files (.ex)
 Generated encryption app
 The database for Encryption.Repo has been created
 ```
 
-
-
 ### 2. Create the `user` Schema (_Database Table_)
 
 In our _example_ `user` database table,
 we are going to store 3 (_primary_) pieces of data.
-+ `name`: the person's name (_encrypted_)
-+ `email`: their email address (_encrypted_)
-+ `password_hash`: the hashed password (_so the person can login_)
+
+* `name`: the person's name (_encrypted_)
+* `email`: their email address (_encrypted_)
+* `password_hash`: the hashed password (_so the person can login_)
 
 In _addition_ to the 3 "_primary_" fields
 we need _**two** more fields_ to store "metadata":
-+ `email_hash`: so we can check ("lookup")
-if an email address is in the database
-_without_ having to _decrypt_ the email(s) stored in the DB.
-+ `key_id`: the id of the **encryption key** used to encrypt the data
-stored in the row. As this is an `id`
-we use an `:integer` to store it in the DB.<sup>1</sup>
+
+* `email_hash`: so we can check ("lookup")
+  if an email address is in the database
+  _without_ having to _decrypt_ the email(s) stored in the DB.
+* `key_id`: the id of the **encryption key** used to encrypt the data
+  stored in the row. As this is an `id`
+  we use an `:integer` to store it in the DB.<sup>1</sup>
 
 Create the `user` schema using the following generator command:
+
 ```sh
 mix phx.gen.schema User users email:binary email_hash:binary name:binary password_hash:binary key_id:integer
 ```
 
 ![phx.gen.schema](https://user-images.githubusercontent.com/194400/35360796-dc4507cc-0156-11e8-9cf1-7f4005e5ed34.png)
-
 
 The _reason_ we are creating the encrypted/hashed fields as `:binary`
 is that the _data_ stored in them will be _encrypted_
@@ -258,8 +260,8 @@ https://dba.stackexchange.com/questions/56934/what-is-the-best-way-to-store-a-lo
 <br />
 and: https://elixir-lang.org/getting-started/binaries-strings-and-char-lists.html
 
-
 Run the "migration" task to create the tables in the Database:
+
 ```sh
 mix ecto.migrate
 ```
@@ -268,7 +270,6 @@ Running the `mix ecto.migrate` command will create the
 `users` table in your `encryption_dev` database. <br />
 You can _view_ this (_empty_) table in **pgAdmin**: <br />
 ![elixir-encryption-pgadmin-user-table](https://user-images.githubusercontent.com/194400/37981997-1ab4362a-31e7-11e8-9bd8-9566834fc199.png)
-
 
 <sup>1</sup> `key_id`:
 _The_ `key_id` _column in our_ `users` _database table,
@@ -279,31 +280,28 @@ that **limits** the amount of data an "attacker" can decrypt
 if the database were ever "compromised"
 (provided we keep the encryption keys safe that is!)_
 
-
 ### 3. Define The 6 Functions
 
 We need 6 functions for encrypting, decrypting, hashing and verifying
 the data we will be storing:
 
-1. **Encrypt** - to encrypt any personal data we want to store in the database.
-2. **Decrypt** - decrypt any data that needs to be viewed.
-3. **Get Key** - get the _latest_ encryption/decryption key
-(_or a **specific** older key where data was encrypted with a different key_)
-4. **Hash Email** (_deterministic & **fast**_) - so that we can "lookup"
-an email without "decrypting".
-The hash of an email address should _always_ be the ***same***.
-5. **Hash Password** (_pseudorandom & **slow**_) - the output of the hash
-should _always_ be ***different*** and relatively **slow** to compute.
-6. **Verify Password** - check a password against the stored `password_hash`
-to confirm that the person "logging-in" has the _correct_ password.
+1.  **Encrypt** - to encrypt any personal data we want to store in the database.
+2.  **Decrypt** - decrypt any data that needs to be viewed.
+3.  **Get Key** - get the _latest_ encryption/decryption key
+    (_or a **specific** older key where data was encrypted with a different key_)
+4.  **Hash Email** (_deterministic & **fast**_) - so that we can "lookup"
+    an email without "decrypting".
+    The hash of an email address should _always_ be the **_same_**.
+5.  **Hash Password** (_pseudorandom & **slow**_) - the output of the hash
+    should _always_ be **_different_** and relatively **slow** to compute.
+6.  **Verify Password** - check a password against the stored `password_hash`
+    to confirm that the person "logging-in" has the _correct_ password.
 
 The next 6 sections of the example/tutorial will walk through
 the creation of (_and testing_) these functions.
 
 > _**Note**: If you have **any questions** on these functions_,
-***please ask***: <br />
-[github.com/dwyl/**phoenix-ecto-encryption-example/issues**](https://github.com/nelsonic/phoenix-ecto-encryption-example/issues)
-
+> **_please ask_**: <br /> > [github.com/dwyl/**phoenix-ecto-encryption-example/issues**](https://github.com/nelsonic/phoenix-ecto-encryption-example/issues)
 
 #### 3.1 Encrypt
 
@@ -335,58 +333,57 @@ is quite simple; (_the "body" is only 4 lines_).<br />
 
 Let's "step through" these lines one at a time:
 
-+ `encrypt/1` accepts one argument; the `plaintext` to be encrypted.
-+ First we create a "**strong**" _random_
-[***initialization vector***](https://en.wikipedia.org/wiki/Initialization_vector)
-(IV) of **16 bytes** (***128 bits***)
-using the Erlang's crypto library `strong_rand_bytes` function:
-http://erlang.org/doc/man/crypto.html#strong_rand_bytes-1
-The "IV" is ensures that each time a string/block of text/data is encrypted,
-the `ciphertext` is _different_.
+* `encrypt/1` accepts one argument; the `plaintext` to be encrypted.
+* First we create a "**strong**" _random_
+  [**_initialization vector_**](https://en.wikipedia.org/wiki/Initialization_vector)
+  (IV) of **16 bytes** (**_128 bits_**)
+  using the Erlang's crypto library `strong_rand_bytes` function:
+  http://erlang.org/doc/man/crypto.html#strong_rand_bytes-1
+  The "IV" is ensures that each time a string/block of text/data is encrypted,
+  the `ciphertext` is _different_.
 
 > Having **different** `ciphertext` each time `plaintext` is encrypted
-is _essential_ for
-["semantic security"](https://en.wikipedia.org/wiki/Semantic_security)
-whereby repeated use of the _same encryption key and algorithm_
-does not allow an "attacker" to infer relationships
-between segments of the encrypted message.
+> is _essential_ for
+> ["semantic security"](https://en.wikipedia.org/wiki/Semantic_security)
+> whereby repeated use of the _same encryption key and algorithm_
+> does not allow an "attacker" to infer relationships
+> between segments of the encrypted message.
 > [Cryptanalysis](https://en.wikipedia.org/wiki/Cryptanalysis) techniques
-are _well_ "beyond scope" for this example/tutorial,
-but we _highly_ encourage to check-out the "Background Reading" links
-at the end and read up on the subject for deeper understanding.
+> are _well_ "beyond scope" for this example/tutorial,
+> but we _highly_ encourage to check-out the "Background Reading" links
+> at the end and read up on the subject for deeper understanding.
 
-+ Next we use the `get_key/0` function
-to retrieve the _latest_ encryption key
-so we can use it to `encrypt` the `plaintext`
-(_the "real"_ `get_key/0` _is defined below in section 3.3_).
+* Next we use the `get_key/0` function
+  to retrieve the _latest_ encryption key
+  so we can use it to `encrypt` the `plaintext`
+  (_the "real"_ `get_key/0` _is defined below in section 3.3_).
 
-+ Then we use the Erlang `block_encrypt` function
-to encrypt the `plaintext`. <br />
-Using `:aes_gcm` ("_Advanced Encryption Standard Galois Counter Mode_"):
-  + `@aad` is a "module attribute" (_Elixir's equivalent of a "constant"_)
-  is defined in `aes.ex` as `@aad "AES256GCM"` <br />
-  this simply defines the encryption mode we are using which,
-  if you break down the code into 3 parts:
-    + AES = Advanced Encryption Standard.
-    + 256 = "256 Bit Key"
-    + GCM = "Galois Counter Mode"
+* Then we use the Erlang `block_encrypt` function
+  to encrypt the `plaintext`. <br />
+  Using `:aes_gcm` ("_Advanced Encryption Standard Galois Counter Mode_"):
 
-+ Finally we "return" the `iv` with the `ciphertag` & `ciphertext`,
-this is what we store in the database.
-Including the IV and ciphertag is _essential_ for allowing decryption,
-without these two pieces of data, we would not be able to "reverse" the process.
+  * `@aad` is a "module attribute" (_Elixir's equivalent of a "constant"_)
+    is defined in `aes.ex` as `@aad "AES256GCM"` <br />
+    this simply defines the encryption mode we are using which,
+    if you break down the code into 3 parts:
+    * AES = Advanced Encryption Standard.
+    * 256 = "256 Bit Key"
+    * GCM = "Galois Counter Mode"
+
+* Finally we "return" the `iv` with the `ciphertag` & `ciphertext`,
+  this is what we store in the database.
+  Including the IV and ciphertag is _essential_ for allowing decryption,
+  without these two pieces of data, we would not be able to "reverse" the process.
 
 > _**Note**: in addition to this_ `encrypt/1` _function,
-we have defined an_ `encrypt/2` _"sister" function which accepts
-a **specific** (encryption)_ `key_id` _so that we can use the desired
-encryption key for encrypting a block of text.
-For the purposes of this example/tutorial,
-it's **not strictly necessary**,
-but it is included for "completeness"_.
-
+> we have defined an_ `encrypt/2` _"sister" function which accepts
+> a **specific** (encryption)_ `key_id` _so that we can use the desired
+> encryption key for encrypting a block of text.
+> For the purposes of this example/tutorial,
+> it's **not strictly necessary**,
+> but it is included for "completeness"_.
 
 ##### Test the `encrypt/1` Function
-
 
 Create a file called `test/lib/aes_test.exs` and _copy-paste_
 the following code into it:
@@ -411,16 +408,15 @@ end
 ```
 
 Run these two tests by running the following command:
+
 ```sh
 mix test test/lib/aes_test.exs
 ```
 
-
 > The full function definitions for AES `encrypt/1` & `encrypt/2` are in:
-[`lib/encryption/aes.ex`](https://github.com/dwyl/phoenix-ecto-encryption-example/blob/master/lib/encryption/aes.ex) <br />
+> [`lib/encryption/aes.ex`](https://github.com/dwyl/phoenix-ecto-encryption-example/blob/master/lib/encryption/aes.ex) <br />
 > And tests are in:
-[`test/lib/aes_test.exs`](https://github.com/dwyl/phoenix-ecto-encryption-example/blob/master/test/lib/aes_test.exs)
-
+> [`test/lib/aes_test.exs`](https://github.com/dwyl/phoenix-ecto-encryption-example/blob/master/test/lib/aes_test.exs)
 
 #### 3.2 Decrypt
 
@@ -442,9 +438,9 @@ The fist step (line) is to "split" the IV from the `ciphertext`
 using Elixir's binary pattern matching.
 
 > If you are unfamiliar with Elixir binary pattern matching syntax:
-`<<iv::binary-16, tag::binary-16, ciphertext::binary>>`
-read the following guide:
-https://elixir-lang.org/getting-started/binaries-strings-and-char-lists.html
+> `<<iv::binary-16, tag::binary-16, ciphertext::binary>>`
+> read the following guide:
+> https://elixir-lang.org/getting-started/binaries-strings-and-char-lists.html
 
 The `:crypto.block_decrypt(:aes_gcm, get_key(), iv, {@aad, ciphertext, tag})`
 line is the _very similar_ to the `encrypt` function.
@@ -452,22 +448,22 @@ line is the _very similar_ to the `encrypt` function.
 The `ciphertext` is decrypted using
 [`block_decrypt/4`](http://erlang.org/doc/man/crypto.html#block_decrypt-4)
 passing in the following parameters:
-+ `:aes_gcm` = encyrption algorithm
-+ `get_key()` =  get the encryption key used to `encrypt` the `plaintext`
-+ `iv` = the original Initialisation Vector used to `encrypt` the `plaintext`
-+ `{@aad, ciphertext, tag}` = a Tuple with the encryption "mode",
-`ciphertext` and the `tag` that was originally used to encrypt the `ciphertext`.
+
+* `:aes_gcm` = encyrption algorithm
+* `get_key()` = get the encryption key used to `encrypt` the `plaintext`
+* `iv` = the original Initialisation Vector used to `encrypt` the `plaintext`
+* `{@aad, ciphertext, tag}` = a Tuple with the encryption "mode",
+  `ciphertext` and the `tag` that was originally used to encrypt the `ciphertext`.
 
 Finally return _just_ the original `plaintext`.
 
 > _**Note**: as above with the_ `encrypt/2` _function,
-we have defined an_ `decrypt/2` _"sister" function which accepts
-a **specific** (encryption)_ `key_id` _so that we can use the desired
-encryption key for decrypting the_ `ciphertext`.
-_For the purposes of this example/tutorial,
-it's **not strictly necessary**,
-but it is included for "completeness"_.
-
+> we have defined an_ `decrypt/2` _"sister" function which accepts
+> a **specific** (encryption)_ `key_id` _so that we can use the desired
+> encryption key for decrypting the_ `ciphertext`.
+> _For the purposes of this example/tutorial,
+> it's **not strictly necessary**,
+> but it is included for "completeness"_.
 
 ##### Test the `decrypt/1` Function
 
@@ -479,14 +475,14 @@ test "decrypt/1 ciphertext that was encrypted with default key" do
   assert plaintext == "hello"
 end
 ```
+
 Re-run the tests `mix test test/lib/aes_test.exs` and confirm they pass.
 
 > The full `encrypt` & `decrypt` function definitions with `@doc` comments
-are in:
-[`lib/encryption/aes.ex`](https://github.com/dwyl/phoenix-ecto-encryption-example/blob/master/lib/encryption/aes.ex)
-<br />
+> are in:
+> [`lib/encryption/aes.ex`](https://github.com/dwyl/phoenix-ecto-encryption-example/blob/master/lib/encryption/aes.ex) <br />
 > And tests are in:
-[`test/lib/aes_test.exs`](https://github.com/dwyl/phoenix-ecto-encryption-example/blob/master/test/lib/aes_test.exs)
+> [`test/lib/aes_test.exs`](https://github.com/dwyl/phoenix-ecto-encryption-example/blob/master/test/lib/aes_test.exs)
 
 #### 3.3 Get (Encryption) Key
 
@@ -513,7 +509,7 @@ as per Erlang/Elixir standard,
 once for each ["arity"](https://en.wikipedia.org/wiki/Arity)
 or number of "arguments".
 In the first case `get_key/0` _assumes_ you want the _latest_ Encryption Key.
-the second case `get_key/1` lets you supply the `key_id` to be "looked up":
+The second case `get_key/1` lets you supply the `key_id` to be "looked up":
 
 Both versions of `get_key` call the `Application.get_env` function:
 `Application.get_env(:encryption, Encryption.AES)[:keys]` _specifically_.
@@ -521,12 +517,12 @@ For this to work we need to define the keys as an Environment Variable
 and make it available to our App in `config.exs`.
 
 > _For the **complete** file containing these functions see_:
-[`lib/encryption/aes.ex`](https://github.com/dwyl/phoenix-ecto-encryption-example/blob/master/lib/encryption/aes.ex)
+> [`lib/encryption/aes.ex`](https://github.com/dwyl/phoenix-ecto-encryption-example/blob/master/lib/encryption/aes.ex)
 
 ##### `ENCRYPTION_KEYS` Environment Variable
 
 In order for our `get_key/0` and `get_key/1` functions to _work_,
-it needs to be know how to "read" the encryption keys.
+it needs to be able to "read" the encryption keys.
 
 We need to "export" an Environment Variable
 containing a (_comma-separated_) list of (_one or more_)
@@ -542,15 +538,15 @@ echo "export ENCRYPTION_KEYS='nMdayQpR0aoasLaq1g94FLba+A+wB44JLko47sVQXMg=,L+ZVX
 > When you are deploying your own App,
 > generate your own AES encryption key(s)
 > see:
-[How To Generate AES Encryption Keys?](https://github.com/dwyl/phoenix-ecto-encryption-example#how-to-generate-aes-encryption-keys)
+> [How To Generate AES Encryption Keys?](https://github.com/dwyl/phoenix-ecto-encryption-example#how-to-generate-aes-encryption-keys)
 > section below for how to do this. <br />
 
 > _**Note**: there are **two** encryption keys separated by a comma.
-This is to **demonstrate** that it's **possible** to use **multiple keys**._
+> This is to **demonstrate** that it's **possible** to use **multiple keys**._
 
 > _We prefer to store our Encryption Keys as
-**Environment Variables** this is consistent with the "12 Factor App"
-best practice:_ https://en.wikipedia.org/wiki/Twelve-Factor_App_methodology
+> **Environment Variables** this is consistent with the "12 Factor App"
+> best practice:_ https://en.wikipedia.org/wiki/Twelve-Factor_App_methodology
 
 ##### Generate the `SECRET_KEY_BASE`
 
@@ -562,8 +558,10 @@ Run the following command to generate a new phoenix secret key:
 ```sh
 mix phx.gen.secret
 ```
+
 _copy-paste_ the _output_ (64bit `String`)
 into your `.env` file after the "equals sign" on the line for `SECRET_KEY_BASE`:
+
 ```yml
 export SECRET_KEY_BASE={YourSecreteKeyBaseGeneratedUsing-mix_phx.gen.secret}
 ```
@@ -589,14 +587,14 @@ Now update the _values_ in your `.env` file the _real_ ones for your App. <br />
 -->
 
 > _**Note**: We are using an_ `.env` _file,
-but if you are using a "Cloud Platform" to deploy your app, <br />
-you could consider using their "Key Management Service"
-for managing encryption keys. eg_: <br />
-+ Heroku:
-https://github.com/dwyl/learn-environment-variables#environment-variables-on-heroku
-+ AWS: https://aws.amazon.com/kms/
-+ Google Cloud: https://cloud.google.com/kms/
+> but if you are using a "Cloud Platform" to deploy your app, <br />
+> you could consider using their "Key Management Service"
+> for managing encryption keys. eg_: <br />
 
+* Heroku:
+  https://github.com/dwyl/learn-environment-variables#environment-variables-on-heroku
+* AWS: https://aws.amazon.com/kms/
+* Google Cloud: https://cloud.google.com/kms/
 
 ##### Test the `get_key/0` and `get_key/1` Functions?
 
@@ -605,23 +603,21 @@ they are not "exported" with the AES module and therefore cannot be _invoked_
 outside of the AES module.
 
 The `get_key/0` and `get_key/1` are _invoked_ by `encrypt/2` and `decrypt/2`
-and thus provided these (public) functions latter functions
+and thus provided these (public) latter functions
 are tested adequately, the "private" functions will be too.
 
 Re-run the tests `mix test test/lib/aes_test.exs` and confirm they _still_ pass.
 
 > The full `encrypt` & `decrypt` function definitions with `@doc` comments
-are in:
-[`lib/encryption/aes.ex`](https://github.com/dwyl/phoenix-ecto-encryption-example/blob/master/lib/encryption/aes.ex)
-<br />
+> are in:
+> [`lib/encryption/aes.ex`](https://github.com/dwyl/phoenix-ecto-encryption-example/blob/master/lib/encryption/aes.ex) > <br />
 > And tests are in:
-[`test/lib/aes_test.exs`](https://github.com/dwyl/phoenix-ecto-encryption-example/blob/master/test/lib/aes_test.exs)
-
+> [`test/lib/aes_test.exs`](https://github.com/dwyl/phoenix-ecto-encryption-example/blob/master/test/lib/aes_test.exs)
 
 #### 3.4 Hash _Email Address_
 
 The idea behind _hashing_ email addresses is to
-so that we can perform a _lookup_ (_in the database_) to check if the
+allow us to perform a _lookup_ (_in the database_) to check if the
 email has _already_ been registered/used for app/system.
 
 Imagine that `alex@example.com` has previously used your app.
@@ -629,6 +625,7 @@ The `SHA256` hash (_encoded as [base64](https://hexdocs.pm/elixir/Base.html)_)
 is: `"bbYebcvPI5DkpGr0JvJqEzo77kUCFCL8euhukTbxQRA="`
 
 `try` it for _yourself_ in `iex`:
+
 ```elixir
 iex(1)> email = "alex@example.com"
 "alex@example.com"
@@ -646,10 +643,8 @@ query = "SELECT * FROM users WHERE email_hash = $1"
 user  = Ecto.Adapters.SQL.query!(Encryption.Repo, query, [hash])
 ```
 
-> _**Note**: there's a "**built-in**" Ecto_
-[`get_by`](https://hexdocs.pm/ecto/Ecto.Repo.html#c:get_by/3) _function
-to perform this type of_ <br />
-``"SELECT ... WHERE field = value"`` _query **effortlessly**_
+> _**Note**: there's a "**built-in**" Ecto_ > [`get_by`](https://hexdocs.pm/ecto/Ecto.Repo.html#c:get_by/3) _function
+> to perform this type of_ <br /> > `"SELECT ... WHERE field = value"` _query **effortlessly**_
 
 Create a file called `lib/encryption/hash_field.ex`
 and include the following code:
@@ -673,12 +668,13 @@ end
 
 The `hash/1` function use Erlang's `crypto` library
 [`hash/2`](http://erlang.org/doc/man/crypto.html#hash-2) function.
-+ First we tell the `hash/2` function that we want to use `:sha256`
-"SHA 256" is the most widely used/recommended hash; it's both fast and "secure".
-+ We then hash the `value` passed in to the `hash/1` function (_we defined_)
-and _concatenate_ it with "salt" using the `get_salt/1` function
-which retrieves the `secret_key_base` environment variable
-and computes a ***unique*** "salt" using the value.
+
+* First we tell the `hash/2` function that we want to use `:sha256`
+  "SHA 256" is the most widely used/recommended hash; it's both fast and "secure".
+* We then hash the `value` passed in to the `hash/1` function (_we defined_)
+  and _concatenate_ it with "salt" using the `get_salt/1` function
+  which retrieves the `secret_key_base` environment variable
+  and computes a **_unique_** "salt" using the value.
 
 We use the `SHA256` one-way hash for _speed_.
 We "salt" the email address so that
@@ -687,23 +683,20 @@ in case the DB is ever "compromised"
 the "attacker" still has to "compute"
 a ["rainbow table"](https://en.wikipedia.org/wiki/Rainbow_table) from _scratch_.
 
-> _**Note**: Don't forget to export your_ `SECRET_KEY_BASE`
-_environment variable_ (_see instructions above_)
+> _**Note**: Don't forget to export your_ `SECRET_KEY_BASE` > _environment variable_ (_see instructions above_)
 
 > The full file containing these two functions is:
-[`lib/encryption/hash_field.ex`](https://github.com/dwyl/phoenix-ecto-encryption-example/blob/master/lib/encryption/hash_field.ex) <br />
+> [`lib/encryption/hash_field.ex`](https://github.com/dwyl/phoenix-ecto-encryption-example/blob/master/lib/encryption/hash_field.ex) <br />
 > And the tests for the functions are:
-[`test/lib/hash_field_test.exs`](https://github.com/dwyl/phoenix-ecto-encryption-example/blob/master/test/lib/hash_field_test.exs)
-
-
+> [`test/lib/hash_field_test.exs`](https://github.com/dwyl/phoenix-ecto-encryption-example/blob/master/test/lib/hash_field_test.exs)
 
 #### 3.5 Hash _Password_
 
 When hashing **passwords**, we want to use the **_strongest_ hashing algorithm**
-and we also want the hashed value (_or "digest"_) to be ***different****
+and we also want the hashed value (_or "digest"_) to be **\*different\*\***
 each time the _same_ `plaintext` is hashed
 (_unlike when hashing the email address
-  where we want a deterministic digest_).
+where we want a deterministic digest_).
 
 Using `argon2` makes "cracking" a password
 (_in the event of the database being "compromised"
@@ -711,7 +704,7 @@ far less likely_) as is has _both_ a CPU-bound "work-factor"
 _and_ a "Memory-hard" algorithm which will _significantly_
 "slow down" the attacker.
 
-##### Add the `argon2` Dependency to
+##### Add the `argon2` Dependency
 
 In order to use `argon2` we must add it to our `mix.exs` file:
 in the `defp deps do` (_dependencies_) section, add the following line:
@@ -722,7 +715,6 @@ in the `defp deps do` (_dependencies_) section, add the following line:
 
 You will need to run `mix deps.get` to install the dependency.
 
-
 ##### Define the `hash_password/1` Function
 
 Create a file called `lib/encryption/password_field.ex` in your project.
@@ -731,7 +723,7 @@ The first function we need is `hash_password/1`:
 ```elixir
 defmodule Encryption.PasswordField do
 
-  def hash(value) do
+  def hash_password(value) do
     Argon2.Base.hash_password(to_string(value),
       Argon2.gen_salt(), [{:argon2_type, 2}])
   end
@@ -739,18 +731,19 @@ defmodule Encryption.PasswordField do
 end
 ```
 
-`hash/1` accepts a password to be hashed and invokes
+`hash_password/1` accepts a password to be hashed and invokes
 [`Argon2.Base.hash_password/3`](https://hexdocs.pm/argon2_elixir/Argon2.Base.html#hash_password/3)
 passing in 3 arguments:
-+ `value` - the value (_password_) to be hashed.
-+ `Argon2.gen_salt()` - the salt used to initialise the hash function
-note: "behind the scenes" just
-[`:crypto.strong_rand_bytes(16)`](https://github.com/riverrun/argon2_elixir/blob/d283a4f316a2a26e61f032a826ff992a480018c2/lib/argon2.ex#L76)
-as we saw before in the `encrypt` function; again,
-**128 bits** is considered "secure" as a hash salt or initialization vector.
-+ `[{:argon2_type, 2}]` - this corresponds to `argon2id` see:
-  + https://github.com/riverrun/argon2_elixir/issues/17
-  + https://crypto.stackexchange.com/questions/48935/why-use-argon2i-or-argon2d-if-argon2id-exists
+
+* `value` - the value (_password_) to be hashed.
+* `Argon2.gen_salt()` - the salt used to initialise the hash function
+  note: "behind the scenes" just
+  [`:crypto.strong_rand_bytes(16)`](https://github.com/riverrun/argon2_elixir/blob/d283a4f316a2a26e61f032a826ff992a480018c2/lib/argon2.ex#L76)
+  as we saw before in the `encrypt` function; again,
+  **128 bits** is considered "secure" as a hash salt or initialization vector.
+* `[{:argon2_type, 2}]` - this corresponds to `argon2id` see:
+  * https://github.com/riverrun/argon2_elixir/issues/17
+  * https://crypto.stackexchange.com/questions/48935/why-use-argon2i-or-argon2d-if-argon2id-exists
 
 ##### 3.5.1 Test the `hash_password/1` Function?
 
@@ -784,14 +777,13 @@ mix test test/lib/password_field_test.exs
 The test should _pass_;
 if _not_, please re-trace the steps.
 
-
 #### 3.6 _Verify_ Password
 
 The _corresponding_ function to _check_ (_or "verify"_)
 the password is `verify_password/2`.
 We need to supply both the `password` and `stored_hash`
 (_the hash that was previously stored in the database
-  when the person registered or updated their password_)
+when the person registered or updated their password_)
 It then runs `Argon2.verify_pass` which does the checking.
 
 ```elixir
@@ -802,7 +794,6 @@ end
 
 `hash_password/1` and `verify_password/2` functions are defined in:
 [`lib/encryption/password_field.ex`](https://github.com/dwyl/phoenix-ecto-encryption-example/blob/master/lib/encryption/password_field.ex)
-
 
 ##### Test for `verify_password/2`
 
@@ -832,9 +823,6 @@ and confirm they pass.
 If you get stuck, see:
 [`test/lib/password_field_test.exs`](https://github.com/dwyl/phoenix-ecto-encryption-example/blob/master/test/lib/password_field_test.exs)
 
-
-
-
 ### 4. _Create_ `EncryptedField` Custom Ecto Type
 
 Writing a few functions to `encrypt`, `decrypt` and `hash` data
@@ -860,28 +848,31 @@ schema "users" do
   timestamps()
 end
 ```
+
 The _default_ Ecto field types (`:binary`) are a good start.
 But we can do _so much_ better if we define _custom_ Ecto Types!
 
 Ecto Custom Types are a way of automatically "_pre-processing_" data
 before inserting it into (_and reading from_) a database.
 Examples of "pre-processing" include:
-+ Custom Validation e.g: phone number or address format.
-+ Encrypting / Decrypting
-+ Hashing
+
+* Custom Validation e.g: phone number or address format.
+* Encrypting / Decrypting
+* Hashing
 
 A custom type expects 4 "callback" functions to be implemented in the file:
-+ [`type/0`](https://hexdocs.pm/ecto/Ecto.Type.html#c:type/0) - define
-the Ecto Type we want Ecto to use to _store_ the data
-for our Custom Type. e.g: `:integer` or `:binary`
-+ [`cast/1`](https://hexdocs.pm/ecto/Ecto.Type.html#c:cast/1) - "typecasts" (_converts_)
-the given data to the desired type e.g: Integer to String.
-+ [`dump/1`](https://hexdocs.pm/ecto/Ecto.Type.html#c:dump/1) - performs the "processing"
-on the raw data before it get's "dumped" into the Ecto Native Type.
-+ [`load/1`](https://hexdocs.pm/ecto/Ecto.Type.html#c:load/1) - called when
-loading data from the database and receive an Ecto native type.
 
-Let's _update_ the `lib/encryption/encrypted_field.ex` file
+* [`type/0`](https://hexdocs.pm/ecto/Ecto.Type.html#c:type/0) - define
+  the Ecto Type we want Ecto to use to _store_ the data
+  for our Custom Type. e.g: `:integer` or `:binary`
+* [`cast/1`](https://hexdocs.pm/ecto/Ecto.Type.html#c:cast/1) - "typecasts" (_converts_)
+  the given data to the desired type e.g: Integer to String.
+* [`dump/1`](https://hexdocs.pm/ecto/Ecto.Type.html#c:dump/1) - performs the "processing"
+  on the raw data before it get's "dumped" into the Ecto Native Type.
+* [`load/1`](https://hexdocs.pm/ecto/Ecto.Type.html#c:load/1) - called when
+  loading data from the database and receive an Ecto native type.
+
+Let's create a `lib/encryption/encrypted_field.ex` file
 by _copy-pasting_ the following code into it:
 
 ```elixir
@@ -944,16 +935,14 @@ Note: Ecto does _not_ invoke this function directly,
 we are using it in our `user.ex` file. (_see below_)
 
 > _**Note**: the_ `load/2` _function is **not required**
-for Ecto Type compliance.
-Further reading_: https://hexdocs.pm/ecto/Ecto.Type.html
+> for Ecto Type compliance.
+> Further reading_: https://hexdocs.pm/ecto/Ecto.Type.html
 
 _Your_ `encrypted_field.ex` Custom Ecto Type should look like this:
 [`lib/encryption/encrypted_field.ex`](https://github.com/dwyl/phoenix-ecto-encryption-example/blob/master/lib/encryption/encrypted_field.ex)
 `try` to write the **tests** for the callback functions,
 if you get "stuck", take a look at:
 [`test/lib/encrypted_field_test.exs`](https://github.com/dwyl/phoenix-ecto-encryption-example/blob/master/test/lib/encrypted_field_test.exs)
-
-
 
 ### 5. _Use_ `EncryptedField` Ecto Type in User Schema
 
@@ -967,7 +956,8 @@ alias Encryption.EncryptedField
 ```
 
 Update the lines for `:email` and `:name` in the schema <br />
-***from***:
+**_from_**:
+
 ```elixir
 schema "users" do
   field :email, :binary
@@ -981,6 +971,7 @@ end
 ```
 
 **To**:
+
 ```elixir
 schema "users" do
   field :email, EncryptedField
@@ -1015,7 +1006,8 @@ end
 
 _Second_, we need to _update_ the `changeset` function
 to include a line calling the `encrypt_fields/1` function: <br />
-***From***:
+**_From_**:
+
 ```elixir
 def changeset(%User{} = user, attrs) do
   user
@@ -1023,7 +1015,9 @@ def changeset(%User{} = user, attrs) do
   |> validate_required([:name, :email, :email_hash])
 end
 ```
+
 **To**:
+
 ```elixir
 def changeset(%User{} = user, attrs \\ %{}) do
   user
@@ -1041,13 +1035,10 @@ and adding `|> encrypt_fields` will encrypt the `:name` and `:email` fields
 prior to the `user` being inserted into the database.
 <br />
 
-> _**Note** we have only added the code to_ `encrypt`
-_the_ `:name` _and_ `:email` _fields on the_ `changeset`.
-_We still need to_ `decrypt` _the data when it is retrieved from the database._
-_Decryption on data retrieval is covered below._
+> _**Note** we have only added the code to_ `encrypt` > _the_ `:name` _and_ `:email` _fields on the_ `changeset`.
+> _We still need to_ `decrypt` _the data when it is retrieved from the database._ > _Decryption on data retrieval is covered below._
 
-
-### 6. Create `HashField ` Ecto Type for Hashing Email Address
+### 6. Create `HashField` Ecto Type for Hashing Email Address
 
 We already added the the `hash/1` _function_ to (SHA256) hash the email address above in
 [**step 3.4**](https://github.com/dwyl/phoenix-ecto-encryption-example#34-hash-email-address),
@@ -1057,12 +1048,12 @@ now we are going to _use_ it in an Ecto Type.
 As we did for the `EncryptedField` Ecto Type in section 4 (_above_),
 the `HashField` needs the same four "ecto callbacks":
 
-+ `type/0` - `:binary` is appropriate for hashed data
-+ `cast/1` - Cast any data type `to_string` before hashing it.
-(_the hashed data will be stored as_ `:binary` _type_)
-+ `dump/1` Calls the `hash/1` function we defined in section 3.4 (_above_).
-+ `load/1` returns the `{:ok, value}` tuple (_unmodified_)
-because a _hash_ cannot be "_undone_".
+* `type/0` - `:binary` is appropriate for hashed data
+* `cast/1` - Cast any data type `to_string` before hashing it.
+  (_the hashed data will be stored as_ `:binary` _type_)
+* `dump/1` Calls the `hash/1` function we defined in section 3.4 (_above_).
+* `load/1` returns the `{:ok, value}` tuple (_unmodified_)
+  because a _hash_ cannot be "_undone_".
 
 The _code_ is pretty straightforward.
 Update the `lib/encryption/hash_field.ex` file to:
@@ -1099,19 +1090,19 @@ defmodule Encryption.HashField do
 end
 ```
 
-
 ### 7. _Use_ `HashField` Ecto Type in User Schema
 
 _First_ add the `alias` for `HashField` near the top
 of the `lib/encryption/user.ex` file. e.g:
+
 ```elixir
 alias Encryption.{User, Repo, EncryptedField, HashField}
 ```
 
-
 _Next_, in the `lib/encryption/user.ex` file,
-***update*** the lines for `email_hash` in the users schema<br />
-***from***:
+**_update_** the lines for `email_hash` in the users schema<br />
+**_from_**:
+
 ```elixir
 schema "users" do
   field :email, EncryptedField
@@ -1124,6 +1115,7 @@ end
 ```
 
 **To**:
+
 ```elixir
 schema "users" do
   field :email, EncryptedField
@@ -1137,6 +1129,7 @@ end
 ```
 
 Then we need to create a function to perform the _hashing_ of `:email` field:
+
 ```elixir
 defp set_hashed_fields(changeset) do
   case changeset.valid? do
@@ -1150,7 +1143,8 @@ end
 ```
 
 _Finally_, add the `set_hashed_fields/1` function call in `changeset/2` pipeline
-***from***:
+**_from_**:
+
 ```elixir
 def changeset(%User{} = user, attrs \\ %{}) do
   user
@@ -1162,6 +1156,7 @@ end
 ```
 
 **To**:
+
 ```elixir
 def changeset(%User{} = user, attrs \\ %{}) do
   user
@@ -1177,7 +1172,6 @@ end
 We should _test_ this new functionality. e.g:
 
 ```elixir
-
   test "inserting a user sets the :email_hash field" do
     user = Repo.insert! User.changeset(%User{}, @valid_attrs)
     assert user.email_hash == Encryption.HashField.hash(@valid_attrs.email)
@@ -1196,7 +1190,6 @@ We should _test_ this new functionality. e.g:
 For the _full_ user tests please see:
 [`test/user/user_test.exs`](https://github.com/dwyl/phoenix-ecto-encryption-example/blob/master/test/user/user_test.exs)
 
-
 ### 8. Create `PasswordField` Ecto Type for Hashing Email Address
 
 We already added the the `hash_password/1` _function_ in
@@ -1206,13 +1199,13 @@ now we are going to _use_ it in an Ecto Type.
 As for the `EncryptedField` and `HashField` Ecto Type in section 4 (_above_),
 the `PasswordField` needs the same four "ecto callbacks":
 
-+ `type/0` - `:binary` is appropriate for hashed data
-+ `cast/1` - Cast any data type `to_string` before hashing it.
-(_the hashed data will be stored as_ `:binary` _type_)
-+ `dump/1` Calls the `hash_password/1` function
-we defined in section 3.5 (_above_).
-+ `load/1` returns the `{:ok, value}` tuple (_unmodified_)
-because a _hash_ cannot be "_undone_".
+* `type/0` - `:binary` is appropriate for hashed data
+* `cast/1` - Cast any data type `to_string` before hashing it.
+  (_the hashed data will be stored as_ `:binary` _type_)
+* `dump/1` Calls the `hash_password/1` function
+  we defined in section 3.5 (_above_).
+* `load/1` returns the `{:ok, value}` tuple (_unmodified_)
+  because a _hash_ cannot be "_undone_".
 
 The _code_ is pretty straightforward.
 Update the `lib/encryption/password_field.ex` file to:
@@ -1246,19 +1239,20 @@ defmodule Encryption.PasswordField do
 end
 ```
 
-
 ### 9. _Use_ `PasswordField` Ecto Type in User Schema
 
 As before, we need to _use_ the `PasswordField` in our User Schema.
 Remember to `alias` the module at the _top_
 of the `lib/encryption/user.ex` file. e.g:
+
 ```elixir
 alias Encryption.{User, Repo, EncryptedField, HashField, PasswordField}
 ```
 
 Now we simply _extend_ the `set_hashed_fields/1` function we defined
 in part 7 (_above_) to set the `:password_hash` field on the `changeset`.
-***From***:
+**_From_**:
+
 ```elixir
 defp set_hashed_fields(changeset) do
   case changeset.valid? do
@@ -1272,6 +1266,7 @@ end
 ```
 
 **To**:
+
 ```elixir
 defp set_hashed_fields(changeset) do
   case changeset.valid? do
@@ -1293,41 +1288,42 @@ For the _full_ `user.ex` code see:
 and tests please see:
 [`test/user/user_test.exs`](https://github.com/dwyl/phoenix-ecto-encryption-example/blob/master/test/user/user_test.exs)
 
-
  <br />
 
 ### 10. Refactor `set_hashed_fields/1` and `encrypt_fields/1`...?
 
 One of the _best_ ways to _confirm_ that you _understood_ the code
 is to attempt to
-[***refactor***](https://en.wikipedia.org/wiki/Code_refactoring) it.
+[**_refactor_**](https://en.wikipedia.org/wiki/Code_refactoring) it.
 
 This step is _optional_ (_you can skip it if you're not confident
 with your Elixir skills_), however it is _recommended_ you at least
 _read_ through it.
 
 > _**Note**: in practice we don't tend to re-factor our code until
-we have shipped it, encountered a "bottleneck" (a need for optimisation)
-**or** we need to **extend** some code and want to make it "DRY" first_.
+> we have shipped it, encountered a "bottleneck" (a need for optimisation)
+> **or** we need to **extend** some code and want to make it "DRY" first_.
 
 > _**Remember**: it's only "refactoring" if there are **complete tests**
-otherwise it's_ ["***roulette***"](https://en.wikipedia.org/wiki/Roulette)!
-(_changing code when you don't have tests,
-will almost **always** result in bugs
-because without tests, not all test cases are considered ..._)
+> otherwise it's_ ["**_roulette_**"](https://en.wikipedia.org/wiki/Roulette)!
+> (_changing code when you don't have tests,
+> will almost **always** result in bugs
+> because without tests, not all test cases are considered ..._)
 
 In order for this refactor to succeed we need to follow these 4 steps:
 
-1. Do not _touch_ the tests.
-  + Ensure that the tests all pass before we start refactoring
+1.  Do not _touch_ the tests.
+
+* Ensure that the tests all pass before we start refactoring
   and that coverage is 100%.
   e.g: https://travis-ci.org/dwyl/phoenix-ecto-encryption-example/jobs/379887597#L833
-2. Update the Schema (_to ensure the data that needs to be hashed
-  is not encrypted before we try to hash it!_)
-3. Create a "generic" function to perform all our data transformations
-that will _replace_ `set_hashed_fields/1` and `encrypt_fields/1`.
-4. Update the `changeset/2` function to _use_ the _new_ function
-and remove the calls to `set_hashed_fields/1` and `encrypt_fields/1`.
+
+2.  Update the Schema (_to ensure the data that needs to be hashed
+    is not encrypted before we try to hash it!_)
+3.  Create a "generic" function to perform all our data transformations
+    that will _replace_ `set_hashed_fields/1` and `encrypt_fields/1`.
+4.  Update the `changeset/2` function to _use_ the _new_ function
+    and remove the calls to `set_hashed_fields/1` and `encrypt_fields/1`.
 
 #### 10.1 Ensure All Tests Pass
 
@@ -1342,15 +1338,16 @@ The corresponding Travis-CI build for this commit is:
 https://travis-ci.org/dwyl/phoenix-ecto-encryption-example/jobs/379887597#L833
 
 > _**Note**: if you are_ `new` _to Travis-CI see_:
-[https://github.com/dwyl/**learn-travis**](https://github.com/dwyl/learn-travis)
+> [https://github.com/dwyl/**learn-travis**](https://github.com/dwyl/learn-travis)
 
 #### 10.2 Re-order `:email_hash` Field in User Schema
 
 We need to re-order the fields in the User schema so that `:email_hash`
-comes ***before*** `:email` so that the email address
+comes **_before_** `:email` so that the email address
 is _not_ encrypted before being hashed whereby
 the hash would always be different!<br />
-***From***:
+**_From_**:
+
 ```elixir
 schema "users" do
   field :email, EncryptedField # :binary
@@ -1419,18 +1416,18 @@ end
 
 This function uses
 ["**type introspection**"](https://en.wikipedia.org/wiki/Type_introspection)
-to determine which fields are on the **Users*** struct (_schema_)
+to determine which fields are on the **Users\*** struct (_schema_)
 we know that hashed fields need the `plaintext` data so we
 return the `primary` field for `:email` and `:password`.
 then loops through those fields and determines what `dump` function
 needs to be applied.
 Finally we apply the `changes` to the `changeset`.
 
-
 #### 10.4 Update `changeset/2` function to use `prepare_fields/1`
 
 The last step is the easiest one. simply update the `changeset/2` function,
-***from***:
+**_from_**:
+
 ```elixir
 def changeset(%User{} = user, attrs \\ %{}) do
   user
@@ -1444,6 +1441,7 @@ end
 ```
 
 **To**:
+
 ```elixir
 def changeset(%User{} = user, attrs \\ %{}) do
   user
@@ -1486,16 +1484,17 @@ Encryption keys should be the appropriate length (in bits)
 as required by the chosen algorithm.
 
 > An **AES 128-bit** key can be expressed
-as a hexadecimal string with 32 characters. <br />
-It will require **24 characters** in **base64**.
+> as a hexadecimal string with 32 characters. <br />
+> It will require **24 characters** in **base64**.
 
 > An **AES 256-bit** key can be expressed
-as a hexadecimal string with 64 characters. <br />
-It will require **44 characters** in **base64**.
+> as a hexadecimal string with 64 characters. <br />
+> It will require **44 characters** in **base64**.
 
 see: https://security.stackexchange.com/a/45334/117318
 
 Open `iex` in your Terminal and paste the following line (_then press enter_)
+
 ```elixir
 :crypto.strong_rand_bytes(32) |> :base64.encode
 ```
@@ -1505,84 +1504,82 @@ You should see terminal output similar to the following:
 ![elixir-generate-encryption-key](https://user-images.githubusercontent.com/194400/38561017-dd93d186-3cce-11e8-91cd-c70f920ac79a.png)
 
 We generated 3 keys for demonstration purposes:
-+ "h6pUk0ZccS0pYsibHZZ4Cd+PRO339rMA7sMz7FnmcGs="
-+ "nMd/yQpR0aoasLaq1g94FL/a+A+wB44JLko47sVQXMg="
-+ "L+ZVX8iheoqgqb22mUpATmMDsvVGt/foAe/0KN5uWf0="
 
-
+* "h6pUk0ZccS0pYsibHZZ4Cd+PRO339rMA7sMz7FnmcGs="
+* "nMd/yQpR0aoasLaq1g94FL/a+A+wB44JLko47sVQXMg="
+* "L+ZVX8iheoqgqb22mUpATmMDsvVGt/foAe/0KN5uWf0="
 
 These two Erlang functions are described in:
-+ http://erlang.org/doc/man/crypto.html#strong_rand_bytes-1
-+ http://erlang.org/doc/man/base64.html#encode-1
+
+* http://erlang.org/doc/man/crypto.html#strong_rand_bytes-1
+* http://erlang.org/doc/man/base64.html#encode-1
 
 Base64 encoding the bytes generated by `strong_rand_bytes`
 will make the output human-readable
 (_whereas bytes are less user-friendly_).
 
-
 <br /> <br />
 
 ## Useful Links, FAQ & Background Reading
 
-+ Bits and Bytes: https://web.stanford.edu/class/cs101/bits-bytes.html
-+ Thinking in Ecto - Schemas and Changesets:
-http://cultofmetatron.io/2017/04/22/thinking-in-ecto---schemas-and-changesets/
-+ Initialization Vector Length:
-https://stackoverflow.com/questions/4608489/how-to-pick-an-appropriate-iv-initialization-vector-for-aes-ctr-nopadding (128 bits is 16 bytes).
-+ What is the effect of the different AES key lengths?
-https://crypto.stackexchange.com/questions/3615/what-is-the-effect-of-the-different-aes-key-lengths
-+ How is decryption done in AES CTR mode?: https://crypto.stackexchange.com/questions/34918/how-is-decryption-done-in-aes-ctr-mode
-+ Block Cipher Counter (CTR) Mode:
-https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Counter_.28CTR.29
-+ Is AES-256 _weaker_ than 192 and 128 bit versions?
-https://crypto.stackexchange.com/questions/5118/is-aes-256-weaker-than-192-and-128-bit-versions
-+ What are the practical differences between 256-bit, 192-bit, and 128-bit AES encryption?
-https://crypto.stackexchange.com/questions/20/what-are-the-practical-differences-between-256-bit-192-bit-and-128-bit-aes-enc
-+ **How to Choose** an **Authenticated Encryption mode**
-(_by Matthew Green cryptography professor at Johns Hopkins University_):
-https://blog.cryptographyengineering.com/2012/05/19/how-to-choose-authenticated-encryption
-+ How to choose an AES encryption mode (CBC ECB CTR OCB CFB)? (v. long answers, but good comparison!)
-https://stackoverflow.com/questions/1220751/how-to-choose-an-aes-encryption-mode-cbc-ecb-ctr-ocb-cfb
-+ AES GCM vs CTR+HMAC tradeoffs:
-https://crypto.stackexchange.com/questions/14747/gcm-vs-ctrhmac-tradeoffs
-+ Galois/Counter Mode for symmetric key cryptographic block ciphers:
-https://en.wikipedia.org/wiki/Galois/Counter_Mode
-+ What is the difference between CBC and GCM mode?
-https://crypto.stackexchange.com/questions/2310/what-is-the-difference-between-cbc-and-gcm-mode
-+ Ciphertext and tag size and IV transmission with AES in GCM mode:
-https://crypto.stackexchange.com/questions/26783/ciphertext-and-tag-size-and-iv-transmission-with-aes-in-gcm-mode
-+ How long (in letters) are encryption keys for AES?
-https://security.stackexchange.com/questions/45318/how-long-in-letters-are-encryption-keys-for-aes
-+ Why we can't implement AES 512 key size?
-https://crypto.stackexchange.com/questions/20253/why-we-cant-implement-aes-512-key-size
-+ Generate random alphanumeric string (_used for AES keys_)
-https://stackoverflow.com/questions/12788799/how-to-generate-a-random-alphanumeric-string-with-erlang
-+ Singular or Plural controller names?: https://stackoverflow.com/questions/35882394/phoenix-controllers-singular-or-plural
-+ What's the purpose of key-rotation?
-https://crypto.stackexchange.com/questions/41796/whats-the-purpose-of-key-rotation
-+ Postgres Data Type for storing `bcrypt` hashed passwords: https://stackoverflow.com/questions/33944199/bcrypt-and-postgresql-what-data-type-should-be-used >> `bytea` (_byte_)
-+ Do security experts recommend bcrypt? https://security.stackexchange.com/questions/4781/do-any-security-experts-recommend-bcrypt-for-password-storage/6415#6415
-+ Hacker News discussion thread "***Don't use `bcrypt`***":
-https://news.ycombinator.com/item?id=3724560
-+ Storing Passwords in a Highly Parallelized World:
-https://hynek.me/articles/storing-passwords
-+ Password hashing security of argon2 versus bcrypt/PBKDF2?
-https://crypto.stackexchange.com/questions/30785/password-hashing-security-of-argon2-versus-bcrypt-pbkdf2
-+ The memory-hard Argon2 password hash function (ietf proposal):
-https://tools.ietf.org/id/draft-irtf-cfrg-argon2-03.html
-unlikely to be a "standard" any time soon...
-+ Erlang Dirty Scheduler Overhead:
-https://medium.com/@jlouis666/erlang-dirty-scheduler-overhead-6e1219dcc7
-+ Erlang Scheduler Details and Why They Matter:
-https://news.ycombinator.com/item?id=11064763
-+ Why use argon2i or argon2d if argon2id exists?
-https://crypto.stackexchange.com/questions/48935/why-use-argon2i-or-argon2d-if-argon2id-exists
-+ Good explanation of _Custom_ Ecto Types:
-https://medium.com/acutario/ecto-custom-types-a-practical-case-with-enumerize-rails-gem-b5496c2912ac
-+ Consider using ETS to store encryption/decryption keys:
-https://elixir-lang.org/getting-started/mix-otp/ets.html &
-https://elixirschool.com/en/lessons/specifics/ets
-
+* Bits and Bytes: https://web.stanford.edu/class/cs101/bits-bytes.html
+* Thinking in Ecto - Schemas and Changesets:
+  http://cultofmetatron.io/2017/04/22/thinking-in-ecto---schemas-and-changesets/
+* Initialization Vector Length:
+  https://stackoverflow.com/questions/4608489/how-to-pick-an-appropriate-iv-initialization-vector-for-aes-ctr-nopadding (128 bits is 16 bytes).
+* What is the effect of the different AES key lengths?
+  https://crypto.stackexchange.com/questions/3615/what-is-the-effect-of-the-different-aes-key-lengths
+* How is decryption done in AES CTR mode?: https://crypto.stackexchange.com/questions/34918/how-is-decryption-done-in-aes-ctr-mode
+* Block Cipher Counter (CTR) Mode:
+  https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Counter_.28CTR.29
+* Is AES-256 _weaker_ than 192 and 128 bit versions?
+  https://crypto.stackexchange.com/questions/5118/is-aes-256-weaker-than-192-and-128-bit-versions
+* What are the practical differences between 256-bit, 192-bit, and 128-bit AES encryption?
+  https://crypto.stackexchange.com/questions/20/what-are-the-practical-differences-between-256-bit-192-bit-and-128-bit-aes-enc
+* **How to Choose** an **Authenticated Encryption mode**
+  (_by Matthew Green cryptography professor at Johns Hopkins University_):
+  https://blog.cryptographyengineering.com/2012/05/19/how-to-choose-authenticated-encryption
+* How to choose an AES encryption mode (CBC ECB CTR OCB CFB)? (v. long answers, but good comparison!)
+  https://stackoverflow.com/questions/1220751/how-to-choose-an-aes-encryption-mode-cbc-ecb-ctr-ocb-cfb
+* AES GCM vs CTR+HMAC tradeoffs:
+  https://crypto.stackexchange.com/questions/14747/gcm-vs-ctrhmac-tradeoffs
+* Galois/Counter Mode for symmetric key cryptographic block ciphers:
+  https://en.wikipedia.org/wiki/Galois/Counter_Mode
+* What is the difference between CBC and GCM mode?
+  https://crypto.stackexchange.com/questions/2310/what-is-the-difference-between-cbc-and-gcm-mode
+* Ciphertext and tag size and IV transmission with AES in GCM mode:
+  https://crypto.stackexchange.com/questions/26783/ciphertext-and-tag-size-and-iv-transmission-with-aes-in-gcm-mode
+* How long (in letters) are encryption keys for AES?
+  https://security.stackexchange.com/questions/45318/how-long-in-letters-are-encryption-keys-for-aes
+* Why we can't implement AES 512 key size?
+  https://crypto.stackexchange.com/questions/20253/why-we-cant-implement-aes-512-key-size
+* Generate random alphanumeric string (_used for AES keys_)
+  https://stackoverflow.com/questions/12788799/how-to-generate-a-random-alphanumeric-string-with-erlang
+* Singular or Plural controller names?: https://stackoverflow.com/questions/35882394/phoenix-controllers-singular-or-plural
+* What's the purpose of key-rotation?
+  https://crypto.stackexchange.com/questions/41796/whats-the-purpose-of-key-rotation
+* Postgres Data Type for storing `bcrypt` hashed passwords: https://stackoverflow.com/questions/33944199/bcrypt-and-postgresql-what-data-type-should-be-used >> `bytea` (_byte_)
+* Do security experts recommend bcrypt? https://security.stackexchange.com/questions/4781/do-any-security-experts-recommend-bcrypt-for-password-storage/6415#6415
+* Hacker News discussion thread "**_Don't use `bcrypt`_**":
+  https://news.ycombinator.com/item?id=3724560
+* Storing Passwords in a Highly Parallelized World:
+  https://hynek.me/articles/storing-passwords
+* Password hashing security of argon2 versus bcrypt/PBKDF2?
+  https://crypto.stackexchange.com/questions/30785/password-hashing-security-of-argon2-versus-bcrypt-pbkdf2
+* The memory-hard Argon2 password hash function (ietf proposal):
+  https://tools.ietf.org/id/draft-irtf-cfrg-argon2-03.html
+  unlikely to be a "standard" any time soon...
+* Erlang Dirty Scheduler Overhead:
+  https://medium.com/@jlouis666/erlang-dirty-scheduler-overhead-6e1219dcc7
+* Erlang Scheduler Details and Why They Matter:
+  https://news.ycombinator.com/item?id=11064763
+* Why use argon2i or argon2d if argon2id exists?
+  https://crypto.stackexchange.com/questions/48935/why-use-argon2i-or-argon2d-if-argon2id-exists
+* Good explanation of _Custom_ Ecto Types:
+  https://medium.com/acutario/ecto-custom-types-a-practical-case-with-enumerize-rails-gem-b5496c2912ac
+* Consider using ETS to store encryption/decryption keys:
+  https://elixir-lang.org/getting-started/mix-otp/ets.html &
+  https://elixirschool.com/en/lessons/specifics/ets
 
 ### Running a Single Test
 

--- a/README.md
+++ b/README.md
@@ -1221,7 +1221,7 @@ defmodule Encryption.PasswordField do
   end
 
   def dump(value) do
-    {:ok, hash(value)}
+    {:ok, hash_password(value)}
   end
 
   def load(value) do


### PR DESCRIPTION
I've gone through the readme and picked out any typos that I could see, added an extra link for another learning resource etc. I think my linter on atom has changed some of the formatting of the file so it looks like everything's changed when it hasn't 🙈! 

The only practical change is that around step 3 there was a typo on the name of the `hash_password` fn which in places was called `hash_password` but somewhere else was just called `hash` and this meant my tests weren't passing. Having now corrected this people should not encounter this error. The same also applies at step 8 where:

```
  def dump(value) do
    {:ok, hash(value)}
  end
```
is now `hash_password(value)`