### PR TITLE
update modules that adopt Ecto.Type behaviour to satisify Ecto 3 requirements

### DIFF
--- a/lib/encryption/encrypted_field.ex
+++ b/lib/encryption/encrypted_field.ex
@@ -24,4 +24,10 @@ defmodule Encryption.EncryptedField do
   def load(value, key_id) do
     {:ok, AES.decrypt(value, key_id)}
   end
+
+  # embed_as/1 dictates how the type behaves when embedded (:self or :dump)
+  def embed_as(_), do: :self # preserve the type's higher level representation
+
+  # equal?/2 is called to determine if two field values are semantically equal
+  def equal?(value1, value2), do: value1 == value2
 end

--- a/lib/encryption/hash_field.ex
+++ b/lib/encryption/hash_field.ex
@@ -15,6 +15,10 @@ defmodule Encryption.HashField do
     {:ok, value}
   end
 
+  def embed_as(_), do: :self
+
+  def equal?(value1, value2), do: value1 == value2
+
   def hash(value) do
     :crypto.hash(:sha256, value <> get_salt(value))
   end

--- a/lib/encryption/password_field.ex
+++ b/lib/encryption/password_field.ex
@@ -15,6 +15,10 @@ defmodule Encryption.PasswordField do
     {:ok, value}
   end
 
+  def embed_as(_), do: :self
+
+  def equal?(value1, value2), do: value1 == value2
+
   def hash_password(value) do
     Argon2.Base.hash_password(to_string(value),
       Argon2.gen_salt(), [{:argon2_type, 2}])

--- a/test/lib/hash_field_test.exs
+++ b/test/lib/hash_field_test.exs
@@ -31,4 +31,15 @@ defmodule Encryption.HashFieldTest do
               248, 22, 254>>
     assert {:ok, ^hash} = Field.load(hash)
   end
+
+  test ".equal? correctly determines hash equality and inequality" do
+    hash1 = <<16, 231, 67, 229, 9, 181, 13, 87, 69, 76, 227, 205, 43, 124, 16,
+              75, 46, 161, 206, 219, 141, 203, 199, 88, 112, 1, 204, 189, 109,
+              248, 22, 254>>
+    hash2 = <<10, 231, 67, 229, 9, 181, 13, 87, 69, 76, 227, 205, 43, 124, 16,
+              75, 46, 161, 206, 219, 141, 203, 199, 88, 112, 1, 204, 189, 109,
+              248, 22, 254>>
+    assert Field.equal?(hash1, hash1)
+    refute Field.equal?(hash1, hash2)
+  end
 end

--- a/test/lib/password_field_test.exs
+++ b/test/lib/password_field_test.exs
@@ -23,6 +23,13 @@ defmodule Encryption.PasswordFieldTest do
     assert {:ok, ^hash} = Field.load(hash)
   end
 
+  test ".equal? correctly determines hash equality and inequality" do
+    hash1 = Field.hash_password("password")
+    hash2 = Field.hash_password("password")
+    assert Field.equal?(hash1, hash1)
+    refute Field.equal?(hash1, hash2)
+  end
+
   test "hash_password/1 uses Argon2id to Hash a value" do
     password = "EverythingisAwesome"
     hash = Field.hash_password(password)


### PR DESCRIPTION
Modules that adopt the `Ecto.Type` behaviour now also implement `equal?/2` and `embed_as` callbacks. Changes:

- updated affected modules
- updated README
- added tests to maintain 100 % coverage