### PR TITLE
Key_id now part of the encrypted binary to make full use of Ecto.Type behaviour

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -19,7 +19,9 @@ config :encryption, Encryption.Repo,
   pool: Ecto.Adapters.SQL.Sandbox
 
 config :encryption, Encryption.AES,
-  key: :base64.decode("vA/K/7K6Z3obnTxlPx6fDuy/tiPj4FS7dDtUpfvRbG4=")
+  keys: [
+    :base64.decode("vA/K/7K6Z3obnTxlPx6fDuy/tiPj4FS7dDtUpfvRbG4=")
+  ]
 
 config :argon2_elixir,
   t_cost: 1,

--- a/lib/encryption/aes.ex
+++ b/lib/encryption/aes.ex
@@ -6,7 +6,8 @@ defmodule Encryption.AES do
   this makes "bruteforce" decryption much more difficult.
   See `encrypt/1` and `decrypt/1` for more details.
   """
-  @aad "AES256GCM" # Use AES 256 Bit Keys for Encryption.
+  # Use AES 256 Bit Keys for Encryption.
+  @aad "AES256GCM"
 
   @doc """
   Encrypt Using AES Galois/Counter Mode (GCM)
@@ -17,30 +18,23 @@ defmodule Encryption.AES do
   ## Parameters
   - `plaintext`: Accepts any data type as all values are converted to a String
     using `to_string` before encryption.
-  - `key_id`: the index of the AES encryption key used to encrypt the ciphertext
   ## Examples
-      iex> Encryption.AES.encrypt("tea", 1) != Encryption.AES.encrypt("tea", 1)
+      iex> Encryption.AES.encrypt("tea") != Encryption.AES.encrypt("tea")
       true
-      iex> ciphertext = Encryption.AES.encrypt(123, 1)
+      iex> ciphertext = Encryption.AES.encrypt(123)
       iex> is_binary(ciphertext)
       true
   """
-  @spec encrypt(any) :: String.t
+  @spec encrypt(any) :: String.t()
   def encrypt(plaintext) do
-    iv = :crypto.strong_rand_bytes(16) # create random Initialisation Vector
-    key = get_key()    # get the *latest* key in the list of encryption keys
-    {ciphertext, tag} =
-      :crypto.block_encrypt(:aes_gcm, key, iv, {@aad, to_string(plaintext), 16})
-    iv <> tag <> ciphertext # "return" iv with the cipher tag & ciphertext
-  end
-
-  @spec encrypt(any, number) :: {String.t, number}
-  def encrypt(plaintext, key_id) do
-    iv = :crypto.strong_rand_bytes(16) # create random Initialisation Vector
-    key = get_key(key_id) # get *specific* key (by id) from list of keys.
-    {ciphertext, tag} =
-      :crypto.block_encrypt(:aes_gcm, key, iv, {@aad, to_string(plaintext), 16})
-    iv <> tag <> ciphertext # "return" iv with the cipher tag & ciphertext
+    iv = :crypto.strong_rand_bytes(16)
+    # get latest key
+    key = get_key()
+    # get latest ID;
+    key_id = get_key_id()
+    # {ciphertext, tag} = :crypto.block_encrypt(:aes_gcm, key, iv, {@aad, plaintext, 16})
+    {ciphertext, tag} = :crypto.block_encrypt(:aes_gcm, key, iv, {@aad, to_string(plaintext), 16})
+    iv <> tag <> <<key_id::unsigned-big-integer-32>> <> ciphertext
   end
 
   @doc """
@@ -50,21 +44,15 @@ defmodule Encryption.AES do
     binary are the IV to use for decryption.
   - `key_id`: the index of the AES encryption key used to encrypt the ciphertext
   ## Example
-      iex> Encryption.AES.encrypt("test") |> Encryption.AES.decrypt(1)
+      iex> Encryption.AES.encrypt("test") |> Encryption.AES.decrypt()
       "test"
   """
-  @spec decrypt(String.t, number) :: {String.t, number}
-  def decrypt(ciphertext, key_id) do # patern match on binary to split parts:
-    <<iv::binary-16, tag::binary-16, ciphertext::binary>> = ciphertext
-    key = get_key(key_id) # get encrytion/decryption key based on key_id
-    :crypto.block_decrypt(:aes_gcm, key, iv, {@aad, ciphertext, tag})
-  end
-
-  # as above but *asumes* `default` (latest) encryption key is used.
-  @spec decrypt(any) :: String.t
+  @spec decrypt(any) :: String.t()
   def decrypt(ciphertext) do
-    <<iv::binary-16, tag::binary-16, ciphertext::binary>> = ciphertext
-    :crypto.block_decrypt(:aes_gcm, get_key(), iv, {@aad, ciphertext, tag})
+    <<iv::binary-16, tag::binary-16, key_id::unsigned-big-integer-32, ciphertext::binary>> =
+      ciphertext
+
+    :crypto.block_decrypt(:aes_gcm, get_key(key_id), iv, {@aad, ciphertext, tag})
   end
 
   # @doc """
@@ -77,16 +65,23 @@ defmodule Encryption.AES do
   #     iex> Encryption.AES.get_key
   #     <<13, 217, 61, 143, 87, 215, 35, 162, 183, 151, 179, 205, 37, 148>>
   # """ # doc commented out because https://stackoverflow.com/q/45171024/1148249
-  @spec get_key() :: String
+  @spec get_key() :: String.t()
   defp get_key do
-    keys = Application.get_env(:encryption, Encryption.AES)[:keys]
-    count = Enum.count(keys) - 1
-    get_key(count)
+    get_key_id() |> get_key
   end
 
-  @spec get_key(number) :: String
+  @spec get_key(number) :: String.t()
   defp get_key(key_id) do
-    keys = Application.get_env(:encryption, Encryption.AES)[:keys]
-    Enum.at(keys, key_id)
+    encryption_keys() |> Enum.at(key_id)
+  end
+
+  @spec get_key_id() :: integer()
+  defp get_key_id do
+    Enum.count(encryption_keys()) - 1
+  end
+
+  @spec encryption_keys() :: list(binary())
+  defp encryption_keys do
+    Application.get_env(:encryption, Encryption.AES)[:keys]
   end
 end

--- a/lib/encryption/encrypted_field.ex
+++ b/lib/encryption/encrypted_field.ex
@@ -1,8 +1,11 @@
 defmodule Encryption.EncryptedField do
-  alias Encryption.AES  # alias our AES encrypt & decrypt functions (3.1 & 3.2)
+  # alias our AES encrypt & decrypt functions (3.1 & 3.2)
+  alias Encryption.AES
 
-  @behaviour Ecto.Type  # Check this module conforms to Ecto.type behavior.
-  def type, do: :binary # :binary is the data type ecto uses internally
+  # Check this module conforms to Ecto.type behavior.
+  @behaviour Ecto.Type
+  # :binary is the data type ecto uses internally
+  def type, do: :binary
 
   # cast/1 simply calls to_string on the value and returns a "success" tuple
   def cast(value) do
@@ -11,8 +14,9 @@ defmodule Encryption.EncryptedField do
 
   # dump/1 is called when the field value is about to be written to the database
   def dump(value) do
-    ciphertext = value |> to_string |> AES.encrypt
-    {:ok, ciphertext} # ciphertext is :binary type (no conversion required)
+    ciphertext = value |> to_string |> AES.encrypt()
+    # ciphertext is :binary type (no conversion required)
+    {:ok, ciphertext}
   end
 
   # load/1 is called when the field is loaded from the database
@@ -20,13 +24,9 @@ defmodule Encryption.EncryptedField do
     {:ok, AES.decrypt(value)}
   end
 
-  # load/2 is called with a specific key_id when the field is loaded from DB
-  def load(value, key_id) do
-    {:ok, AES.decrypt(value, key_id)}
-  end
-
   # embed_as/1 dictates how the type behaves when embedded (:self or :dump)
-  def embed_as(_), do: :self # preserve the type's higher level representation
+  # preserve the type's higher level representation
+  def embed_as(_), do: :self
 
   # equal?/2 is called to determine if two field values are semantically equal
   def equal?(value1, value2), do: value1 == value2

--- a/lib/encryption/user.ex
+++ b/lib/encryption/user.ex
@@ -8,7 +8,6 @@ defmodule Encryption.User do
     field(:email_hash, HashField)
     # :binary
     field(:email, EncryptedField)
-    field(:key_id, :integer)
     # :binary
     field(:name, EncryptedField)
     # virtual means "don't persist"
@@ -24,109 +23,25 @@ defmodule Encryption.User do
   Creates a changeset based on the user and attrs
   """
   def changeset(%User{} = user, attrs \\ %{}) do
-    # hash and/or encrypt the personal data before db insert!
-    #  only after the email has been hashed!
     user
-    |> Map.merge(attrs)
     |> cast(attrs, [:name, :email])
-    |> validate_required([:name, :email])
-    |> prepare_fields
+    |> validate_required([:email])
+    |> add_email_hash
     |> unique_constraint(:email_hash)
-  end
-
-  # prepare_fields/1 takes changeset and applies the reuired "dump" function.
-  defp prepare_fields(changeset) do
-    #  don't bother transforming the data if invalid.
-    case changeset.valid? do
-      true ->
-        # get name of Ecto Struct. e.g: User
-        struct = changeset.data.__struct__
-        # get list of fields in the Struct
-        fields = struct.__schema__(:fields)
-        # create map of data transforms stackoverflow.com/a/29924465/1148249
-        changes =
-          Enum.reduce(fields, %{}, fn field, acc ->
-            type = struct.__schema__(:type, field)
-            # only check the changeset if it's "valid" and
-            if String.contains?(Atom.to_string(type), "Encryption.") do
-              primary =
-                case type do
-                  # "priary" field for :email_hash is :email
-                  Encryption.HashField ->
-                    :email
-
-                  Encryption.PasswordField ->
-                    :password
-
-                  _ ->
-                    field
-                end
-
-              # get plaintext data
-              data = Map.get(changeset.data, primary)
-              # dump (encrypt/hash)
-              {:ok, transformed_value} = type.dump(data)
-              # assign key:value to Map
-              Map.put(acc, field, transformed_value)
-            else
-              # always return the accumulator to avoid "nil is not a map!"
-              acc
-            end
-          end)
-
-        #  apply the changes to the changeset
-        %{changeset | changes: changes}
-
-      _ ->
-        # return the changeset unmodified for the next function in pipe
-        changeset
-    end
-  end
-
-  @doc """
-  Retrieve one user from the database and decrypt the encrypted data.
-  """
-  def one() do
-    user =
-      %User{name: name, email: email, key_id: key_id, password_hash: password_hash} =
-      Repo.one(User)
-
-    {:ok, email} = EncryptedField.load(email, key_id)
-    {:ok, name} = EncryptedField.load(name, key_id)
-    %{user | email: email, name: name, password_hash: password_hash}
   end
 
   @doc """
   Retrieve one user from the database by email address
   """
   def get_by_email(email) do
-    result = Repo.get_by(User, email_hash: HashField.hash(email))
-
-    case result do
-      # checking for nil case: github.com/elixir-ecto/ecto/issues/1225
-      nil ->
-        {:error, "user not found"}
-
-      _ ->
-        user =
-          %User{
-            name: name,
-            email: email,
-            key_id: key_id,
-            password_hash: password_hash
-          } = result
-
-        {:ok, email} = EncryptedField.load(email, key_id)
-        {:ok, name} = EncryptedField.load(name, key_id)
-        {:ok, %{user | email: email, name: name, password_hash: password_hash}}
-    end
+    Repo.get_by(User, email_hash: email)
   end
-end
 
-defmodule Util do
-  types = ~w[function nil integer binary bitstring list map float atom tuple pid port reference]
-
-  for type <- types do
-    def typeof(x) when unquote(:"is_#{type}")(x), do: unquote(type)
+  defp add_email_hash(changeset) do
+    if Map.has_key?(changeset.changes, :email) do
+      changeset |> put_change(:email_hash, changeset.changes.email)
+    else
+      changeset
+    end
   end
 end

--- a/priv/repo/migrations/20200512150858_remove_key_id_from_users.exs
+++ b/priv/repo/migrations/20200512150858_remove_key_id_from_users.exs
@@ -1,0 +1,9 @@
+defmodule Consultify.Repo.Migrations.RemoveKeyIdFromUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      remove(:key_id)
+    end
+  end
+end

--- a/test/lib/aes_test.exs
+++ b/test/lib/aes_test.exs
@@ -9,7 +9,7 @@ defmodule Encryption.AESTest do
   end
 
   test ".encrypt can encrypt a number" do
-    assert is_binary(AES.encrypt(123, 1))
+    assert is_binary(AES.encrypt(123))
   end
 
   test ".encrypt includes the random IV in the value" do
@@ -20,27 +20,35 @@ defmodule Encryption.AESTest do
     assert is_binary(ciphertext)
   end
 
+  test ".encrypt includes the key_id in the value" do
+    <<_iv::binary-16, _tag::binary-16, key_id::unsigned-big-integer-32, _ciphertext::binary>> =
+      AES.encrypt("hello")
+
+    assert key_id == 0
+  end
+
   test ".encrypt does not produce the same ciphertext twice" do
     assert AES.encrypt("hello") != AES.encrypt("hello")
   end
 
   test "can decrypt a value" do
-    keys = Application.get_env(:encryption, Encryption.AES)[:keys]
-    key_id = Enum.count(keys) - 1
-    plaintext = "hello" |> AES.encrypt |> AES.decrypt(key_id)
+    plaintext = "hello" |> AES.encrypt() |> AES.decrypt()
     assert plaintext == "hello"
   end
 
-  test "can decrypt/2 a value" do
-    keys = Application.get_env(:encryption, Encryption.AES)[:keys]
-    key_id = Enum.count(keys) - 1
-    ciphertext = AES.encrypt("hello", key_id)
-    plaintext = AES.decrypt(ciphertext, key_id)
-    assert plaintext == "hello"
-  end
+  test "can still decrypt the value after adding a new encryption key" do
+    encrypted_value = "hello" |> AES.encrypt()
 
-  test "decrypt/1 ciphertext that was encrypted with default key" do
-    plaintext = "hello" |> AES.encrypt |> AES.decrypt()
-    assert plaintext == "hello"
+    original_keys = Application.get_env(:encryption, Encryption.AES)[:keys]
+
+    # add a new key
+    Application.put_env(:encryption, Encryption.AES,
+      keys: original_keys ++ [:crypto.strong_rand_bytes(32)]
+    )
+
+    assert "hello" == encrypted_value |> AES.decrypt()
+
+    # rollback to the original keys
+    Application.put_env(:encryption, Encryption.AES, keys: original_keys)
   end
 end

--- a/test/lib/encrypted_field_test.exs
+++ b/test/lib/encrypted_field_test.exs
@@ -3,7 +3,7 @@ defmodule Encryption.EncryptedFieldTest do
   alias Encryption.EncryptedField, as: Field
 
   test ".type is :binary" do
-    assert Field.type == :binary
+    assert Field.type() == :binary
   end
 
   test ".cast converts a value to a string" do
@@ -15,12 +15,5 @@ defmodule Encryption.EncryptedFieldTest do
 
     assert ciphertext != "hello"
     assert String.length(ciphertext) != 0
-  end
-
-  test ".load decrypts a value" do
-    {:ok, ciphertext} = Field.dump("hello")
-    keys = Application.get_env(:encryption, Encryption.AES)[:keys]
-    key_id = Enum.count(keys) - 1
-    assert {:ok, "hello"} == Field.load(ciphertext, key_id)
   end
 end

--- a/test/lib/hash_field_test.exs
+++ b/test/lib/hash_field_test.exs
@@ -1,9 +1,10 @@
 defmodule Encryption.HashFieldTest do
   use ExUnit.Case
-  alias Encryption.HashField, as: Field # our Ecto Custom Type for hashed fields
+  # our Ecto Custom Type for hashed fields
+  alias Encryption.HashField, as: Field
 
   test ".type is :binary" do
-    assert Field.type == :binary
+    assert Field.type() == :binary
   end
 
   test ".cast converts a value to a string" do
@@ -13,32 +14,37 @@ defmodule Encryption.HashFieldTest do
 
   test ".dump converts a value to a sha256 hash" do
     {:ok, hash} = Field.dump("hello")
-    assert hash == <<12, 25, 78, 36, 26, 203, 166, 213, 129, 193, 199, 22, 51,
-                    10, 239, 208, 6, 222, 237, 9, 12, 197, 118, 96, 149, 176,
-                    40, 4, 95, 241, 219, 112>>
+
+    assert hash ==
+             <<12, 25, 78, 36, 26, 203, 166, 213, 129, 193, 199, 22, 51, 10, 239, 208, 6, 222,
+               237, 9, 12, 197, 118, 96, 149, 176, 40, 4, 95, 241, 219, 112>>
   end
 
   test ".hash converts a value to a sha256 hash with secret_key_base as salt" do
     hash = Field.hash("alex@example.com")
-    assert hash == <<74, 63, 196, 137, 191, 105, 153, 76, 235, 10, 244, 55,
-                    153, 170, 114, 88, 70, 219, 118, 187, 190, 91, 169, 181,
-                    140, 24, 79, 133, 247, 228, 115, 220>>
+
+    assert hash ==
+             <<74, 63, 196, 137, 191, 105, 153, 76, 235, 10, 244, 55, 153, 170, 114, 88, 70, 219,
+               118, 187, 190, 91, 169, 181, 140, 24, 79, 133, 247, 228, 115, 220>>
   end
 
   test ".load does not modify the hash, since the hash cannot be reversed" do
-    hash = <<16, 231, 67, 229, 9, 181, 13, 87, 69, 76, 227, 205, 43, 124, 16,
-              75, 46, 161, 206, 219, 141, 203, 199, 88, 112, 1, 204, 189, 109,
-              248, 22, 254>>
+    hash =
+      <<16, 231, 67, 229, 9, 181, 13, 87, 69, 76, 227, 205, 43, 124, 16, 75, 46, 161, 206, 219,
+        141, 203, 199, 88, 112, 1, 204, 189, 109, 248, 22, 254>>
+
     assert {:ok, ^hash} = Field.load(hash)
   end
 
   test ".equal? correctly determines hash equality and inequality" do
-    hash1 = <<16, 231, 67, 229, 9, 181, 13, 87, 69, 76, 227, 205, 43, 124, 16,
-              75, 46, 161, 206, 219, 141, 203, 199, 88, 112, 1, 204, 189, 109,
-              248, 22, 254>>
-    hash2 = <<10, 231, 67, 229, 9, 181, 13, 87, 69, 76, 227, 205, 43, 124, 16,
-              75, 46, 161, 206, 219, 141, 203, 199, 88, 112, 1, 204, 189, 109,
-              248, 22, 254>>
+    hash1 =
+      <<16, 231, 67, 229, 9, 181, 13, 87, 69, 76, 227, 205, 43, 124, 16, 75, 46, 161, 206, 219,
+        141, 203, 199, 88, 112, 1, 204, 189, 109, 248, 22, 254>>
+
+    hash2 =
+      <<10, 231, 67, 229, 9, 181, 13, 87, 69, 76, 227, 205, 43, 124, 16, 75, 46, 161, 206, 219,
+        141, 203, 199, 88, 112, 1, 204, 189, 109, 248, 22, 254>>
+
     assert Field.equal?(hash1, hash1)
     refute Field.equal?(hash1, hash2)
   end

--- a/test/lib/password_field_test.exs
+++ b/test/lib/password_field_test.exs
@@ -1,9 +1,10 @@
 defmodule Encryption.PasswordFieldTest do
   use ExUnit.Case
-  alias Encryption.PasswordField, as: Field # our Ecto Custom Type
+  # our Ecto Custom Type
+  alias Encryption.PasswordField, as: Field
 
   test ".type is :binary" do
-    assert Field.type == :binary
+    assert Field.type() == :binary
   end
 
   test ".cast converts a value to a string" do


### PR DESCRIPTION
I implemented the idea of @moritzploss as he suggested in #33 

This solved several issues:

* double (implicit and explicit) encryption and decryption is unnecessary
* now we make full use of the Ecto.Type behaviour and we are able to remove the complicated prepare_fields/1 function
* In the previous implementation key rotation would simple not work. After adding a new key the initial decryption through the load function (as defined as Ecto.Type behaviour) of an already encrypted field would always be done with the *latest* encryption key, which would cause an error because it was encrypted with the second last encryption key.
* The original prepare_fields/1 function could not handle parameters with keys as string because of extra merging of the attrs, which is a common practice done in controllers.